### PR TITLE
fix: rename haumea tests

### DIFF
--- a/.github/workflows/flake_evaltests.yml
+++ b/.github/workflows/flake_evaltests.yml
@@ -1,4 +1,4 @@
-name: Nix Flake Unit Tests
+name: Nix Flake Eval Tests
 
 on:
   push:
@@ -34,7 +34,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             experimental-features = nix-command flakes
 
-      - name: Run Nix Flake Unit Tests
+      - name: Run Nix Flake Eval Tests
         run: |
-          echo 'Flake Unit Tests'
-          nix eval .#unitTests --show-trace --print-build-logs --verbose
+          echo 'Flake Eval Tests'
+          nix eval .#evalTests --show-trace --print-build-logs --verbose

--- a/outputs/README.md
+++ b/outputs/README.md
@@ -12,7 +12,7 @@ otherwise, it will be difficult to manage and maintain them.
 Unit Tests for all flake outputs(only NixOS systems currently).
 
 ```bash
-nix eval .#unitTests --show-trace --print-build-logs --verbose
+nix eval .#evalTests --show-trace --print-build-logs --verbose
 ```
 
 ## Overview

--- a/outputs/aarch64-linux/default.nix
+++ b/outputs/aarch64-linux/default.nix
@@ -31,7 +31,7 @@ in
     inherit data; # for debugging purposes
 
     # NixOS's unit tests.
-    unitTests = haumea.lib.loadEvalTests {
+    evalTests = haumea.lib.loadEvalTests {
       src = ./tests;
       inputs = args // {inherit outputs;};
     };

--- a/outputs/default.nix
+++ b/outputs/default.nix
@@ -53,7 +53,7 @@ in {
   debugAttrs = {inherit nixosSystems darwinSystems allSystems allSystemNames;};
 
   # Unit Tests for all NixOS systems.
-  unitTests = lib.lists.all (it: it.unitTests == {}) nixosSystemValues;
+  evalTests = lib.lists.all (it: it.evalTests == {}) nixosSystemValues;
 
   # NixOS Hosts
   nixosConfigurations =

--- a/outputs/riscv64-linux/default.nix
+++ b/outputs/riscv64-linux/default.nix
@@ -31,7 +31,7 @@ in
     inherit data; # for debugging purposes
 
     # NixOS's unit tests.
-    unitTests = haumea.lib.loadEvalTests {
+    evalTests = haumea.lib.loadEvalTests {
       src = ./tests;
       inputs = args // {inherit outputs;};
     };

--- a/outputs/x86_64-linux/default.nix
+++ b/outputs/x86_64-linux/default.nix
@@ -30,7 +30,7 @@ in
     inherit data; # for debugging purposes
 
     # NixOS's unit tests.
-    unitTests = haumea.lib.loadEvalTests {
+    evalTests = haumea.lib.loadEvalTests {
       src = ./tests;
       inputs = args // {inherit outputs;};
     };


### PR DESCRIPTION
Here we actually run the nix code related to all hosts, so we can't call it a unit test, it's more accurate to call it eval tests.