### PR TITLE
feat(xdg): use imv-dir instead to auto select the directory where the image is located.

### DIFF
--- a/home/linux/desktop/base/xdg.nix
+++ b/home/linux/desktop/base/xdg.nix
@@ -69,11 +69,11 @@
 
         "audio/*" = ["mpv.desktop"];
         "video/*" = ["mpv.dekstop"];
-        "image/*" = ["imv.desktop"];
-        "image/gif" = ["imv.desktop"];
-        "image/jpeg" = ["imv.desktop"];
-        "image/png" = ["imv.desktop"];
-        "image/webp" = ["imv.desktop"];
+        "image/*" = ["imv-dir.desktop"];
+        "image/gif" = ["imv-dir.desktop"];
+        "image/jpeg" = ["imv-dir.desktop"];
+        "image/png" = ["imv-dir.desktop"];
+        "image/webp" = ["imv-dir.desktop"];
       };
 
       associations.removed = {


### PR DESCRIPTION
feat(xdg): use imv-dir instead to auto selects the directory where the image is located.