### PR TITLE
fix: option `nix.registry.nixpkgs.to.path' has conflicting definition

### DIFF
--- a/modules/nixos/base/nix.nix
+++ b/modules/nixos/base/nix.nix
@@ -17,13 +17,5 @@
   # https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-auto-optimise-store
   nix.settings.auto-optimise-store = true;
 
-  # make `nix run nixpkgs#nixpkgs` use the same nixpkgs as the one used by this flake.
-  nix.registry.nixpkgs.flake = nixpkgs;
   nix.channel.enable = false; # remove nix-channel related tools & configs, we use flakes instead.
-
-  # but NIX_PATH is still used by many useful tools, so we set it to the same value as the one used by this flake.
-  # Make `nix repl '<nixpkgs>'` use the same nixpkgs as the one used by this flake.
-  environment.etc."nix/inputs/nixpkgs".source = "${nixpkgs}";
-  # https://github.com/NixOS/nix/issues/9574
-  nix.settings.nix-path = lib.mkForce "nixpkgs=/etc/nix/inputs/nixpkgs";
 }


### PR DESCRIPTION
Caused by https://github.com/NixOS/nixpkgs/pull/254405