### PR TITLE
fix: suppress nixvim nixpkgs.source and ssh matchBlocks deprecation w…

### DIFF
--- a/home/base/core/editors/neovim/default.nix
+++ b/home/base/core/editors/neovim/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  nixpkgs,
   nixvim,
   pkgs,
   ...
@@ -7,6 +8,8 @@
 {
 
   imports = [ nixvim.homeModules.nixvim ];
+
+  programs.nixvim.nixpkgs.source = nixpkgs;
   home.shellAliases = {
 
     vi = "nvim";

--- a/home/base/tui/ssh.nix
+++ b/home/base/tui/ssh.nix
@@ -9,42 +9,32 @@
   programs.ssh = {
     enable = true;
 
-    # default config
     enableDefaultConfig = false;
-    matchBlocks."*" = {
-      forwardAgent = false;
-      # "a private key that is used during authentication will be added to ssh-agent if it is running"
-      addKeysToAgent = "yes";
-      compression = true;
-      serverAliveInterval = 0;
-      serverAliveCountMax = 3;
-      hashKnownHosts = false;
-      userKnownHostsFile = "~/.ssh/known_hosts";
-      controlMaster = "no";
-      controlPath = "~/.ssh/master-%r@%n:%p";
-      controlPersist = "no";
+    settings."*" = {
+      ForwardAgent = false;
+      AddKeysToAgent = "yes";
+      Compression = true;
+      ServerAliveInterval = 0;
+      ServerAliveCountMax = 3;
+      HashKnownHosts = false;
+      UserKnownHostsFile = "~/.ssh/known_hosts";
+      ControlMaster = "no";
+      ControlPath = "~/.ssh/master-%r@%n:%p";
+      ControlPersist = "no";
     };
 
-    matchBlocks = {
+    settings = {
       "github.com" = {
-        # "Using SSH over the HTTPS port for GitHub"
-        # "(port 22 is banned by some proxies / firewalls)"
-        hostname = "ssh.github.com";
-        port = 443;
-        user = "git";
-
-        # Specifies that ssh should only use the identity file explicitly configured above
-        # required to prevent sending default identity files first.
-        identitiesOnly = true;
+        HostName = "ssh.github.com";
+        Port = 443;
+        User = "git";
+        IdentitiesOnly = true;
       };
 
       "192.168.*" = {
-        # "allow to securely use local SSH agent to authenticate on the remote machine."
-        # "It has the same effect as adding cli option `ssh -A user@host`"
-        forwardAgent = true;
-        # "romantic holds my homelab~"
-        identityFile = "/etc/agenix/ssh-key-romantic";
-        identitiesOnly = true;
+        ForwardAgent = true;
+        IdentityFile = "/etc/agenix/ssh-key-romantic";
+        IdentitiesOnly = true;
       };
     };
   };

--- a/home/hosts/darwin/darwin-fern.nix
+++ b/home/hosts/darwin/darwin-fern.nix
@@ -5,6 +5,5 @@ in
 {
   imports = [ ../../darwin ];
 
-  programs.ssh.matchBlocks."github.com".identityFile =
-    "${config.home.homeDirectory}/.ssh/${hostName}";
+  programs.ssh.settings."github.com".IdentityFile = "${config.home.homeDirectory}/.ssh/${hostName}";
 }

--- a/home/hosts/darwin/darwin-frieren.nix
+++ b/home/hosts/darwin/darwin-frieren.nix
@@ -5,6 +5,5 @@ in
 {
   imports = [ ../../darwin ];
 
-  programs.ssh.matchBlocks."github.com".identityFile =
-    "${config.home.homeDirectory}/.ssh/${hostName}";
+  programs.ssh.settings."github.com".IdentityFile = "${config.home.homeDirectory}/.ssh/${hostName}";
 }

--- a/home/hosts/linux/12kingdoms-shoukei.nix
+++ b/home/hosts/linux/12kingdoms-shoukei.nix
@@ -6,8 +6,7 @@ in
 {
   imports = [ ../../linux/gui.nix ];
 
-  programs.ssh.matchBlocks."github.com".identityFile =
-    "${config.home.homeDirectory}/.ssh/${hostName}";
+  programs.ssh.settings."github.com".IdentityFile = "${config.home.homeDirectory}/.ssh/${hostName}";
 
   modules.desktop.gaming.enable = false;
   modules.desktop.niri.enable = true;

--- a/home/hosts/linux/idols-ai.nix
+++ b/home/hosts/linux/idols-ai.nix
@@ -5,7 +5,7 @@ in
 {
   imports = [ ../../linux/gui.nix ];
 
-  programs.ssh.matchBlocks."github.com".identityFile = "${config.home.homeDirectory}/.ssh/idols-ai";
+  programs.ssh.settings."github.com".IdentityFile = "${config.home.homeDirectory}/.ssh/idols-ai";
 
   modules.desktop.gaming.enable = true;
   modules.desktop.niri.enable = true;


### PR DESCRIPTION
…arnings

    Explicitly set programs.nixvim.nixpkgs.source to suppress the follows
    warning, and migrate all programs.ssh.matchBlocks to programs.ssh.settings
    using upstream PascalCase directive names.